### PR TITLE
feat: add user config types via jsdoc

### DIFF
--- a/source/init.ts
+++ b/source/init.ts
@@ -27,7 +27,10 @@ export const init = async () => {
   )
   await writePrettyFile(
     configPath,
-    `module.exports = ${JSON.stringify(config, null, 2)}`,
+    `/**
+    * @type { import("./dist/types/utils/get-config").Config }
+    */
+    module.exports = ${JSON.stringify(config, null, 2)}`,
     'babel'
   )
 }


### PR DESCRIPTION
`pinecone init` to include jsdoc types for pinecone.config.js